### PR TITLE
Update readme and correct the use of datetime_picker.

### DIFF
--- a/app/views/application/index.html.slim
+++ b/app/views/application/index.html.slim
@@ -1,38 +1,63 @@
 .row
   .col-sm-6
-    p Simple Usage
+    p
+      strong Simple Usage
+    p Defaults to a DateTime format of 'DD/MM/YY MM:HH A'.
+
+    hr
     = simple_form_for Event.new do |f|
       = f.input :when, as: :date_time_picker
-    hr
+
+    p
+      strong Code
     pre
       | = simple_form_for Event.new do |f|
       br
       |   f.input :when, as: :date_time_picker
   .col-sm-6
-    p With customized options
+    p
+      strong Customized Options
+    p Refer to #{link_to "Bootstrap 3 Datepicker's Doc", "http://eonasdan.github.io/bootstrap-datetimepicker/Options/"} for a full list of options.
+
+    hr
     = simple_form_for Event.new do |f|
       = f.input :when, as: :date_time_picker, input_html: \
         { data: \
-          { date_format: "YYYY-MM-DD hh:mm A", \
-            date_useminutes: false, \
-            date_sidebyside: false, \
-            date_mindate: Time.current.strftime('%Y-%m-%d') \
+          { \
+            date_format: "YYYY-MM-DD hh:mm A", \
+            date_day_view_header_format: 'MMM YYYY', \
+            date_side_by_side: true, \
+            date_min_date: Time.current.strftime('%Y-%m-%d') \
           } \
         }
-    hr
+
+    p
+      strong Code
     pre
-      | = f.input :starts_at, as: :date_time_picker, input_html:
+      | = f.input :when, as: :date_time_picker, input_html:
       br
       |   { data:
       br
-      |     { date_format: "YYYY-MM-DD hh:mm A",
+      |     {
       br
-      |       date_useminutes: false,
+      |       date_format: "YYYY-MM-DD hh:mm A",
       br
-      |       date_sidebyside: false,
+      |       date_day_view_header_format: 'MMM YYYY',
       br
-      |       date_mindate: Time.current.strftime('%Y-%m-%d')
+      |       date_side_by_side: true,
+      br
+      |       date_min_date: Time.current.strftime('%Y-%m-%d')
       br
       |     }
       br
       |   }
+
+    p #{link_to "Bootstrap 3 Datepicker", "https://github.com/Eonasdan/bootstrap-datetimepicker/blob/master/src/js/bootstrap-datetimepicker.js#L291"} provides the option to initialize a datetime picker through the use of <code>data</code> attributes on the <code>input</code> field.
+
+    p To do that, modify any of the options specified in #{link_to "Bootstrap 3 Datepicker's Doc", "http://eonasdan.github.io/bootstrap-datetimepicker/Options/"} by adding a prefix of <code>date</code> and underscoring the resulting option.
+
+    p
+      ' For example:
+      ul
+       li <code>dayViewHeaderFormat</code> to <code>date_day_view_header_format</code>
+       li <code>minDate</code> to <code>date_min_date</code>

--- a/app/views/application/index.html.slim
+++ b/app/views/application/index.html.slim
@@ -52,9 +52,9 @@
       br
       |   }
 
-    p #{link_to "Bootstrap 3 Datepicker", "https://github.com/Eonasdan/bootstrap-datetimepicker/blob/master/src/js/bootstrap-datetimepicker.js#L291"} provides the option to initialize a datetime picker through the use of <code>data</code> attributes on the <code>input</code> field.
+    p #{link_to "Bootstrap 3 Datepicker", "https://github.com/Eonasdan/bootstrap-datetimepicker/blob/master/src/js/bootstrap-datetimepicker.js#L291"} is able to initialize a datetime picker through the use of <code>data</code> attributes on the <code>input</code> field.
 
-    p To do that, modify any of the options specified in #{link_to "Bootstrap 3 Datepicker's Doc", "http://eonasdan.github.io/bootstrap-datetimepicker/Options/"} by adding a prefix of <code>date</code> and underscoring the resulting option.
+    p To do that, modify any of the options specified in #{link_to "Bootstrap 3 Datepicker's Doc", "http://eonasdan.github.io/bootstrap-datetimepicker/Options/"} by adding a prefix of <code>date</code> and underscoring the resulting option name.
 
     p
       ' For example:

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,20 +8,24 @@ html
 
     meta name='viewport' content='width=device-width, initial-scale=1'
   body
+    / GitHub Fork Ribbon
+    a href="https://github.com/jollygoodcode/datetime_picker_input"
+      img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"
+
     header style='padding: 20px 0 40px 0; background: #ff7a95; color: white;'
       .container
         h1 style='font-size: 50px;' Datetime Picker Input
         p style='font-size: 18px; font-weight: 300; color: #ffdde4;'
-          ' Documentation for #{link_to 'datetime_picker_input', 'https://github.com/jollygoodcode/datetime_picker_input', style: 'color: #fff;'} that adds a JavaScript datetime picker easily
+          ' Demo app for #{link_to 'datetime_picker_input', 'https://github.com/jollygoodcode/datetime_picker_input', style: 'color: #fff;'} that allows you to easily add a JavaScript datetime picker
           br
-          ' to your Ruby on Rails, Bootstrap-enabled SimpleForm inputs.
+          ' to your Ruby on Rails, Bootstrap-enabled Simple Form input.
 
     .container
       section
         h3 Prerequisites
         hr
-        p This gem is Rails 4+ compatible only, and your app should already have Bootstrap and SimpleForm installed.
-        p Otherwise, set up #{link_to 'Bootstrap', 'https://github.com/twbs/bootstrap-sass'} and #{link_to 'SimpleForm', 'https://github.com/plataformatec/simple_form'} now.
+        p This gem is Rails 3.1 and 4+ compatible, and your app should already have Bootstrap and Simple Form installed.
+        p Otherwise, set up #{link_to 'Bootstrap', 'https://github.com/twbs/bootstrap-sass'} and #{link_to 'Simple Form', 'https://github.com/plataformatec/simple_form'} now.
 
       section
         h3 Installation
@@ -53,15 +57,16 @@ html
           ' To
           = link_to "customize the input field", "https://github.com/plataformatec/simple_form/wiki/Adding-custom-input-components"
           ' ,
-          ' you can generate the files by generator provided by
+          ' you can copy <code>datetime_picker_input.rb</code> from the gem to your app by using the generator included in
           = link_to "datetime_picker_input", "https://github.com/jollygoodcode/datetime_picker_input"
-          | :
+          | .
+        p Simply do:
         pre
           ' $ rails g datetime_picker_input:install
         p This will generate <code>datetime_picker_input.rb</code> under <code>app/inputs</code> directory. Then you can start customizing it.
 
       section
-        h3 Credits
+        h3 Dependencies
         hr
         p
           ' This gem is heavily dependent on and only possible because of the great work done in these other gems:
@@ -69,14 +74,15 @@ html
           li= link_to 'https://github.com/TrevorS/bootstrap3-datetimepicker-rails'
           li= link_to 'https://github.com/derekprior/momentjs-rails'
 
-    javascript:
-      window.twttr=(function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],t=window.twttr||{};if(d.getElementById(id))return;js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);t._e=[];t.ready=function(f){t._e.push(f);};return t;}(document,"script","twitter-wjs"));
+    footer.text-center style='padding: 20px 0'
 
-    footer.text-center style='padding: 40px 0 20px;'
+      javascript:
+        window.twttr=(function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],t=window.twttr||{};if(d.getElementById(id))return;js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);t._e=[];t.ready=function(f){t._e.push(f);};return t;}(document,"script","twitter-wjs"));
+
       .container
         hr
         p
-          ' Made with <3 by
+          ' Made with love by
           = link_to "Jolly Good Code", "http://jollygoodcode.com"
           | .
         p

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -16,7 +16,7 @@ html
       .container
         h1 style='font-size: 50px;' Datetime Picker Input
         p style='font-size: 18px; font-weight: 300; color: #ffdde4;'
-          ' Demo app for #{link_to 'datetime_picker_input', 'https://github.com/jollygoodcode/datetime_picker_input', style: 'color: #fff;'} that allows you to easily add a JavaScript datetime picker
+          ' Demo app for #{link_to 'datetime_picker_input', 'https://github.com/jollygoodcode/datetime_picker_input', style: 'color: #fff;'} that allows you to easily add a #{link_to 'JavaScript datetime picker', 'http://eonasdan.github.io/bootstrap-datetimepicker/', style: 'color: #fff;'}
           br
           ' to your Ruby on Rails, Bootstrap-enabled Simple Form input.
 
@@ -24,7 +24,7 @@ html
       section
         h3 Prerequisites
         hr
-        p This gem is Rails 3.1 and 4+ compatible, and your app should already have Bootstrap and Simple Form installed.
+        p Rails 3.1 and 4+ compatible, and your app should already have Bootstrap and Simple Form installed.
         p Otherwise, set up #{link_to 'Bootstrap', 'https://github.com/twbs/bootstrap-sass'} and #{link_to 'Simple Form', 'https://github.com/plataformatec/simple_form'} now.
 
       section
@@ -63,13 +63,13 @@ html
         p Simply do:
         pre
           ' $ rails g datetime_picker_input:install
-        p This will generate <code>datetime_picker_input.rb</code> under <code>app/inputs</code> directory. Then you can start customizing it.
+        p This will generate <code>datetime_picker_input.rb</code> under <code>app/inputs</code> directory which you can modify.
 
       section
         h3 Dependencies
         hr
         p
-          ' This gem is heavily dependent on and only possible because of the great work done in these other gems:
+          ' This gem is heavily dependent on and only possible because of the great work done in these gems:
         ul
           li= link_to 'https://github.com/TrevorS/bootstrap3-datetimepicker-rails'
           li= link_to 'https://github.com/derekprior/momentjs-rails'


### PR DESCRIPTION
The options passed to `datetime_picker_input` was incorrect. 

This PR fixes that and also have general updates to the readme.
